### PR TITLE
①修改了application.yml

### DIFF
--- a/ProjectManagementSystem/src/main/resources/application.yml
+++ b/ProjectManagementSystem/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 mybatis:
   type-aliases-package: com.seisoul.projectmanagementsystem.pojo
-  mapperLocations: classpath:com/seisoul/projectmanagementsystem/mapper/*.xml
+  mapperLocations: classpath:com/seisoul/projectmanagementsystem/mapper/*.xml # 配置mapper路径
+  configuration:
+    map-underscore-to-camel-case: true # 开启自动匹配大小写,就使用驼峰命名了
+
 
 spring:
   datasource:


### PR DESCRIPTION
在mybatis:的配置里新添加了一个配置
  configuration:
    map-underscore-to-camel-case: true
作用是开启驼峰命名规则适配
举例:
java的对象里有一个名为userName的变量
数据库表格里有一个名为user_name的属性
当把user_name的数据传入到userName时,如果没有把
"configuration:map-underscore-to-camel-case"设置为true,则表格里的user_name不会配对到java对象的userName变量(因为驼峰命名), 当开启configuration:map-underscore-to-camel-case时,则表格里的user_name会自动配对到java对象的userName变量.